### PR TITLE
Update meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "viam:golang-wifi-example",
+  "module_id": "viam:golang-wifi-example",
   "visibility": "private",
   "url": "https://github.com/viam-labs/wifi-sensor",
   "description": "Example module for golang",


### PR DESCRIPTION
Name has been deprecated in favor of module_id and will no longer work with the newest versions of the cli