### PR TITLE
trigger cloud builds on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: viamrobotics/build-action@main
+      with:
+        version: ${{ inputs.version }}
+        key-id: ${{ secrets.viam_key_id }}
+        key-value: ${{ secrets.viam_key_value }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
     inputs:
       version:
         type: string
+  push:
 
 jobs:
   build:


### PR DESCRIPTION
## What changed
- add a new workflow, build.yml, which uses viamrobotics/build-action
- this uses a blank version for now (i.e. just build, don't upload)