### PR TITLE
APP-3484 apple silicon

### DIFF
--- a/linuxwifi/linuxwifi.go
+++ b/linuxwifi/linuxwifi.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 // Package linuxwifi implements a wifi strength sensor
 package linuxwifi
 
@@ -7,8 +5,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
@@ -69,48 +65,5 @@ func (sensor *wifi) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 
 // Readings returns Wifi strength statistics.
 func (sensor *wifi) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	dump, err := os.ReadFile(sensor.path)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make(map[string]interface{})
-	lines := strings.Split(strings.TrimSpace(string(dump)), "\n")
-	for i, line := range lines {
-		if i < 2 {
-			continue
-		}
-		iface, readings, err := sensor.readingsByInterface(line)
-		if err != nil {
-			return nil, err
-		}
-		result[iface] = readings
-	}
-
-	return result, nil
-}
-
-func (sensor *wifi) readingsByInterface(line string) (string, map[string]interface{}, error) {
-	fields := strings.Fields(line)
-
-	iface := strings.TrimRight(fields[0], ":")
-
-	link, err := strconv.ParseInt(strings.TrimRight(fields[2], "."), 10, 32)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "invalid link quality reading")
-	}
-	level, err := strconv.ParseInt(strings.TrimRight(fields[3], "."), 10, 32)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "invalid wifi level reading")
-	}
-	noise, err := strconv.ParseInt(fields[4], 10, 32)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "invalid wifi noise reading")
-	}
-
-	return iface, map[string]interface{}{
-		"link_quality": int(link),
-		"level_dBm":    int(level),
-		"noise_dBm":    int(noise),
-	}, nil
+	return platformReadings(sensor.path)
 }

--- a/linuxwifi/readings_darwin.go
+++ b/linuxwifi/readings_darwin.go
@@ -1,0 +1,22 @@
+package linuxwifi
+
+import (
+	"os/exec"
+	"strings"
+)
+
+const airportCli string = "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport"
+
+func platformReadings(_ string) (map[string]interface{}, error) {
+	out, err := exec.Command(airportCli, "-I").Output()
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]interface{})
+	for _, line := range strings.Split(string(out), "\n") {
+		if before, after, found := strings.Cut(strings.Trim(line, " "), ": "); found {
+			ret[before] = after
+		}
+	}
+	return ret, nil
+}

--- a/linuxwifi/readings_linux.go
+++ b/linuxwifi/readings_linux.go
@@ -1,0 +1,56 @@
+package linuxwifi
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func platformReadings(path string) (map[string]interface{}, error) {
+	dump, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]interface{})
+	lines := strings.Split(strings.TrimSpace(string(dump)), "\n")
+	for i, line := range lines {
+		if i < 2 {
+			continue
+		}
+		iface, readings, err := readingsByInterface(line)
+		if err != nil {
+			return nil, err
+		}
+		result[iface] = readings
+	}
+
+	return result, nil
+}
+
+func readingsByInterface(line string) (string, map[string]interface{}, error) {
+	fields := strings.Fields(line)
+
+	iface := strings.TrimRight(fields[0], ":")
+
+	link, err := strconv.ParseInt(strings.TrimRight(fields[2], "."), 10, 32)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "invalid link quality reading")
+	}
+	level, err := strconv.ParseInt(strings.TrimRight(fields[3], "."), 10, 32)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "invalid wifi level reading")
+	}
+	noise, err := strconv.ParseInt(fields[4], 10, 32)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "invalid wifi noise reading")
+	}
+
+	return iface, map[string]interface{}{
+		"link_quality": int(link),
+		"level_dBm":    int(level),
+		"noise_dBm":    int(noise),
+	}, nil
+}

--- a/meta.json
+++ b/meta.json
@@ -11,7 +11,7 @@
   ],
   "build": {
     "build": "make module.tar.gz",
-    "arch" : ["linux/amd64", "linux/arm64"]
+    "arch" : ["linux/amd64", "linux/arm64", "darwin/arm64"]
   },
   "entrypoint": "wifi"
 }


### PR DESCRIPTION
## What changed
- factor out `sensor.Readings` to platform-specific implementations
- add mac readings implementation using `airport` command
- add apple silicon target in meta.json (see this build successfully [here](https://github.com/viam-labs/wifi-sensor/actions/runs/7331700044/job/19964737963#step:3:1970))